### PR TITLE
Add delivery calendar page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains a minimal Flask application with a small note taking
 example using SQLite. The home page still displays "Hello, World!" and a
 "Notes" page lets you create notes with categories which are stored in a local
 `notes.db` file. A new "Deliveries" page lets you track deliveries made to a
-construction site.
+construction site. The "Delivery Calendar" page shows deliveries on a monthly
+calendar.
 
 ## Setup
 
@@ -26,4 +27,6 @@ Then open [http://127.0.0.1:5000/](http://127.0.0.1:5000/) in your browser to se
 the greeting. The notes page is available at
 [http://127.0.0.1:5000/notes](http://127.0.0.1:5000/notes) and the deliveries
 page at
-[http://127.0.0.1:5000/deliveries](http://127.0.0.1:5000/deliveries).
+[http://127.0.0.1:5000/deliveries](http://127.0.0.1:5000/deliveries). The
+calendar is available at
+[http://127.0.0.1:5000/calendar](http://127.0.0.1:5000/calendar).

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,8 @@
     <a href="{{ url_for('index') }}">Home</a> |
     <a href="{{ url_for('notes') }}">Notes</a> |
     <a href="{{ url_for('calc') }}">Calculator</a> |
-    <a href="{{ url_for('deliveries') }}">Deliveries</a>
+    <a href="{{ url_for('deliveries') }}">Deliveries</a> |
+    <a href="{{ url_for('calendar_view') }}">Delivery Calendar</a>
 </nav>
 <hr>
 {% block content %}{% endblock %}

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Delivery Calendar - {{ year }}-{{ '%02d'|format(month) }}</h1>
+<table border="1" cellpadding="5" cellspacing="0">
+    <tr>
+        <th>Mon</th>
+        <th>Tue</th>
+        <th>Wed</th>
+        <th>Thu</th>
+        <th>Fri</th>
+        <th>Sat</th>
+        <th>Sun</th>
+    </tr>
+    {% for week in weeks %}
+    <tr>
+        {% for day in week %}
+        <td valign="top" style="width:120px;height:80px;">
+            {% if day != 0 %}
+                <strong>{{ day }}</strong><br>
+                {% for d in deliveries_by_day.get(day, []) %}
+                    <div>{{ d['item'] }} ({{ d['quantity'] }})</div>
+                {% endfor %}
+            {% endif %}
+        </td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- include a Delivery Calendar link in the navbar
- support a new `/calendar` route and template
- show deliveries for the current month on a calendar grid
- document the new page in the README

## Testing
- `python -m py_compile app.py`