### PR TITLE
Enable drag and drop for calendar tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,7 @@ def calendar_view():
     month = today.month
     conn = get_db_connection()
     deliveries = conn.execute(
-        "SELECT item, quantity, supplier, delivery_date FROM deliveries WHERE strftime('%Y-%m', delivery_date) = ?",
+        "SELECT id, item, quantity, supplier, delivery_date FROM deliveries WHERE strftime('%Y-%m', delivery_date) = ?",
         (f"{year:04d}-{month:02d}",),
     ).fetchall()
     conn.close()
@@ -134,6 +134,21 @@ def calendar_view():
         year=year,
         month=month,
     )
+
+
+@app.route('/move_delivery', methods=['POST'])
+def move_delivery():
+    data = request.get_json()
+    delivery_id = int(data.get('id'))
+    new_date = data.get('new_date')
+    conn = get_db_connection()
+    conn.execute(
+        'UPDATE deliveries SET delivery_date = ? WHERE id = ?',
+        (new_date, delivery_id),
+    )
+    conn.commit()
+    conn.close()
+    return '', 204
 
 if __name__ == '__main__':
     init_db()

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -14,11 +14,11 @@
     {% for week in weeks %}
     <tr>
         {% for day in week %}
-        <td valign="top" style="width:120px;height:80px;">
+        <td valign="top" style="width:120px;height:80px;" {% if day != 0 %}data-date="{{ year }}-{{ '%02d'|format(month) }}-{{ '%02d'|format(day) }}" ondragover="dragover_handler(event)" ondrop="drop_handler(event)"{% endif %}>
             {% if day != 0 %}
                 <strong>{{ day }}</strong><br>
                 {% for d in deliveries_by_day.get(day, []) %}
-                    <div>{{ d['item'] }} ({{ d['quantity'] }})</div>
+                    <div draggable="true" ondragstart="dragstart_handler(event)" data-id="{{ d['id'] }}">{{ d['item'] }} ({{ d['quantity'] }})</div>
                 {% endfor %}
             {% endif %}
         </td>
@@ -26,4 +26,28 @@
     </tr>
     {% endfor %}
 </table>
+<script>
+function dragstart_handler(ev) {
+    ev.dataTransfer.setData('text/plain', ev.target.dataset.id);
+}
+function dragover_handler(ev) {
+    ev.preventDefault();
+}
+function drop_handler(ev) {
+    ev.preventDefault();
+    const id = ev.dataTransfer.getData('text/plain');
+    const date = ev.currentTarget.dataset.date;
+    fetch('/move_delivery', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: id, new_date: date })
+    }).then(resp => {
+        if (resp.ok) {
+            ev.currentTarget.appendChild(document.querySelector('[data-id="' + id + '"]'));
+        } else {
+            alert('Move failed');
+        }
+    });
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow `calendar.html` events to be draggable
- add endpoint to update delivery dates when an event is dropped

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: The server started but was killed)*