### PR TITLE
Reload calendar on delivery drop

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -43,7 +43,8 @@ function drop_handler(ev) {
         body: JSON.stringify({ id: id, new_date: date })
     }).then(resp => {
         if (resp.ok) {
-            ev.currentTarget.appendChild(document.querySelector('[data-id="' + id + '"]'));
+            // Reload the page so the calendar reflects the updated delivery date
+            window.location.reload();
         } else {
             alert('Move failed');
         }


### PR DESCRIPTION
## Summary
- refresh the calendar page after moving a delivery so the changes are reflected immediately

## Testing
- `python -m py_compile app.py`
