### PR TITLE
Add simple warehouse page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ the greeting. The notes page is available at
 [http://127.0.0.1:5000/notes](http://127.0.0.1:5000/notes) and the deliveries
 page at
 [http://127.0.0.1:5000/deliveries](http://127.0.0.1:5000/deliveries). The
+warehouse page is at
+[http://127.0.0.1:5000/magazyn](http://127.0.0.1:5000/magazyn). The
 calendar is available at
 [http://127.0.0.1:5000/calendar](http://127.0.0.1:5000/calendar).
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,6 +12,7 @@
     <a class="me-2" href="{{ url_for('notes') }}">Notes</a>
     <a class="me-2" href="{{ url_for('calc') }}">Calculator</a>
     <a class="me-2" href="{{ url_for('deliveries') }}">Deliveries</a>
+    <a class="me-2" href="{{ url_for('magazyn') }}">Magazyn</a>
     <a class="me-2" href="{{ url_for('calendar_view') }}">Delivery Calendar</a>
 </nav>
 <hr>

--- a/templates/warehouse.html
+++ b/templates/warehouse.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Magazyn</h1>
+<form method="post">
+    <label for="name">Item:</label><br>
+    <input type="text" id="name" name="name" required><br>
+    <label for="quantity">Quantity:</label><br>
+    <input type="number" id="quantity" name="quantity" required><br>
+    <label for="location">Location:</label><br>
+    <input type="text" id="location" name="location" required><br>
+    <button type="submit" class="btn btn-primary">Add Item</button>
+</form>
+<hr>
+{% for item in items %}
+<h2>{{ item['name'] }}</h2>
+<strong>Quantity:</strong> {{ item['quantity'] }}<br>
+<strong>Location:</strong> {{ item['location'] }}
+<form method="post" action="{{ url_for('delete_item', item_id=item['id']) }}" class="mt-2">
+    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+</form>
+<hr>
+{% endfor %}
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add navigation link for a new Magazyn (warehouse) page
- create new warehouse table in the DB
- implement routes for viewing, adding and deleting warehouse items
- provide a warehouse template
- mention the new page in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`